### PR TITLE
Fix the failing upload manifest while populating satellite

### DIFF
--- a/playbooks/satellite/roles/satellite-populate/tasks/main.yaml
+++ b/playbooks/satellite/roles/satellite-populate/tasks/main.yaml
@@ -18,7 +18,7 @@
     until: "{{ uploading.rc }} == 0"
     retries: 5
     delay: 10
-    when: "copying.changed"
+    when: "manifesting.stat.exists is defined or manifesting.stat.exists == "true" or copying.changed"
 
   # TODO: We want to be sure manifest is in the Sat before we start trying
   # to enable repos. There have to be some better way, but for now this


### PR DESCRIPTION
Check if the manifest is already present and upload it the condition evaluates to true

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>