### PR TITLE
Add support for Overlay FS cleanup

### DIFF
--- a/playbooks/satellite/roles/docker-host/tasks/main.yaml
+++ b/playbooks/satellite/roles/docker-host/tasks/main.yaml
@@ -125,7 +125,31 @@
     shell: |
       lvs --separator ':' "/dev/mapper/{{ docker_host_vg }}" | grep '^\s*docker-pool:' \
         && lvremove --force "/dev/mapper/{{ docker_host_vg }}-docker--pool" || true
-  ###-name: "No docker overlay FS present"   # TODO
+  
+  # Cleanup Overlay FS configuration if present
+  - name: "Check if we have an Overlay configured"
+    command:
+      grep "/dev/{{ docker_host_vg }}/docker" /etc/fstab
+    register: overlay_present
+    always_run: True
+    ignore_errors: True
+  - name: "Unmount the partition"
+    mount:
+      src: "/dev/{{ docker_host_vg }}/docker"
+      name: /var/lib/docker
+      state: unmounted
+    when: overlay_present.rc == 0
+  - name: "Cleanup /etc/fstab"
+    lineinfile:
+      name: /etc/fstab
+      regexp: '^/dev/{{ docker_host_vg }}/docker'
+      state: absent
+    when: overlay_present.rc == 0
+  - name: "Remove overlay device"
+    command:
+      lvremove -f "{{ docker_host_vg }}"
+    when: overlay_present.rc == 0
+
   - name: "Docker storage related config ready to be recreated"
     shell: |
       rm -rf /var/lib/docker/*

--- a/playbooks/satellite/roles/satellite-populate/tasks/main.yaml
+++ b/playbooks/satellite/roles/satellite-populate/tasks/main.yaml
@@ -18,7 +18,7 @@
     until: "{{ uploading.rc }} == 0"
     retries: 5
     delay: 10
-    when: "copying.changed"
+    when: "manifesting.stat.exists is defined or manifesting.stat.exists == "true" or copying.changed"
 
   # TODO: We want to be sure manifest is in the Sat before we start trying
   # to enable repos. There have to be some better way, but for now this


### PR DESCRIPTION
Added support for cleaning up Overlay FS configurations and volume groups
The commits adds the following tasks:
- Checks if the overlay was already configure
- Unmounts the path at which overlay was mounted
- Cleans up /etc/fstab
- Removes the volume group associated with overlay

Addresses #24 