### PR TITLE
docker-tierdown should also cleanup ssh known_hosts

### DIFF
--- a/playbooks/satellite/docker-tierdown.yaml
+++ b/playbooks/satellite/docker-tierdown.yaml
@@ -5,6 +5,17 @@
   roles:
   ###  - common
   tasks:
+    - name: "Get docker container ips to clear up known_hosts file"
+      shell: |
+        for c in $(docker ps -q); do
+          docker inspect $c | python -c "import json,sys;obj=json.load(sys.stdin);print obj[0][\"NetworkSettings\"][\"IPAddress\"]"
+        done > /root/docker-ips.txt
+    - name: "Clear up ssh known_hosts before killing containers"
+      shell:
+        grep -vwF -f /root/docker-ips.txt /root/.ssh/known_hosts > /root/.ssh/known_hosts_new
+    - name: "Keep cleaned up known hosts only"
+      shell:
+        rm -f /root/.ssh/known_hosts && mv /root/.ssh/known_hosts_new /root/.ssh/known_hosts
     - name: "Restart docker daemon what kills all containers"
       service:
         name: docker

--- a/playbooks/satellite/docker-tierdown.yaml
+++ b/playbooks/satellite/docker-tierdown.yaml
@@ -5,17 +5,9 @@
   roles:
   ###  - common
   tasks:
-    - name: "Get docker container ips to clear up known_hosts file"
-      shell: |
-        for c in $(docker ps -q); do
-          docker inspect $c | python -c "import json,sys;obj=json.load(sys.stdin);print obj[0][\"NetworkSettings\"][\"IPAddress\"]"
-        done > /root/docker-ips.txt
     - name: "Clear up ssh known_hosts before killing containers"
       shell:
-        grep -vwF -f /root/docker-ips.txt /root/.ssh/known_hosts > /root/.ssh/known_hosts_new
-    - name: "Keep cleaned up known hosts only"
-      shell:
-        rm -f /root/.ssh/known_hosts && mv /root/.ssh/known_hosts_new /root/.ssh/known_hosts
+        truncate -s 0 /root/.ssh/known_hosts
     - name: "Restart docker daemon what kills all containers"
       service:
         name: docker


### PR DESCRIPTION
docker-tierdown should also cleanup ssh known_hosts so as to prevent from ssh authentication errors
Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>