### PR TITLE
Clearup docker active network connections

### DIFF
--- a/playbooks/satellite/docker-tierdown.yaml
+++ b/playbooks/satellite/docker-tierdown.yaml
@@ -8,6 +8,9 @@
     - name: "Clear up ssh known_hosts before killing containers"
       shell:
         truncate -s 0 /root/.ssh/known_hosts
+    - name: "Clear docker active network connections(sometimes prevents docker from restarting)"
+      shell:
+        rm -rf /var/lib/docker/network/files/
     - name: "Restart docker daemon what kills all containers"
       service:
         name: docker


### PR DESCRIPTION
Sometimes, if the containers are interrupted they might be holding some active network connection
This prevents docker service from restarting normally
PR adds a task into docker-tierdown.yaml to clear up these active network connections