### PR TITLE
Add customizations to ansible behaviour

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,9 @@
+[ssh_connection]
+control_path = %(directory)s/%%h-%%r
+ssh_args = -o ControlMaster=auto -o ControlPersist=1800s
+
+[defaults]
+forks = 10
+host_key_checking = False
+inventory = conf/hosts.ini
+


### PR DESCRIPTION
The PR makes the following changes:
- Fix support for systems with long hostnames
- Increase the SSH ControlPersist to improve upon performance
- Increase the default number of forks ansible uses from 5 to 10
- Disable host key checking while executing playbooks
- Sets the default inventory file to conf/hosts.ini

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>