### PR TITLE
Changed and Update miscellaneous stuff.

### DIFF
--- a/conf/satperf.yaml
+++ b/conf/satperf.yaml
@@ -11,7 +11,11 @@ rhsm_user: your_portal_username
 rhsm_pass: your_portal_passowd
 rhsm_pool: 'Pool you want to consume'
 
+# Skip, Remove home partition and Extend Root partiion.
+extend_root_partition: true
+
 # Satellite
+sat_version: "6.2"
 sat_user: admin
 sat_pass: changeme
 sat_email: root@localhost
@@ -71,6 +75,7 @@ content_content_view_name: test
 client_private_key: "{{ satperf_private_key }}"   # key to access clients (containers)
 
 # Capsule install options
+base_capsule_pool: 'Pool you want to consume' # Needs to contain Base RHEL7 repo, which is set via rhsm-satellite, as every manifest may not have 'Employee SKU'.
 sat_capsule_pool: 'Pool you want to consume'   # Needs to contain Capsule
 capsule_install_source: cdn   # either 'cdn' or 'repo'
                               #   'cdn' ... configure value of 'capsule_cdn_reponame'

--- a/playbooks/satellite/capsules.yaml
+++ b/playbooks/satellite/capsules.yaml
@@ -14,6 +14,7 @@
     ###- upgrade-restart
     ###- capsule-ec2-partitioning
     - remove-home-extend-root
+      when: "extend_root_partition == 'true'"
     - capsule
     - capsule-location
     - enlarge-arp-table

--- a/playbooks/satellite/installation.yaml
+++ b/playbooks/satellite/installation.yaml
@@ -13,6 +13,7 @@
     ###- upgrade-restart
     ###- satellite-ec2-partitioning
     - remove-home-extend-root
+      when: "extend_root_partition == 'true'"
     - setup
     - enlarge-arp-table
     - satellite-populate

--- a/playbooks/satellite/roles/capsule/tasks/main.yaml
+++ b/playbooks/satellite/roles/capsule/tasks/main.yaml
@@ -73,13 +73,24 @@
       name="{{ capsule_installer_pkg }}"
       state=present
 
-  # Prepare for capsule installation
+  # Prepare for 6.2  capsule installation
   - name: "Run capsule-certs-generate on Satellite"
     shell:
       "capsule-certs-generate --capsule-fqdn {{ item }} --certs-tar /var/www/html/pub/{{ item }}-certs.tar >/var/www/html/pub/{{ item }}-out.raw"
     delegate_to: "{{ groups['satellite6']|first }}"
     run_once: true
     with_items: "{{ groups['capsules'] }}"
+    when: "sat_version == '6.2'"
+
+  # Prepare for 6.3  capsule installation
+  # NOTE: The change of --capsule-fqdn to --foreman-proxy-fqdn for Sat6.3
+  - name: "Run capsule-certs-generate on Satellite"
+    shell:
+      "capsule-certs-generate --foreman-proxy-fqdn {{ item }} --certs-tar /var/www/html/pub/{{ item }}-certs.tar >/var/www/html/pub/{{ item }}-out.raw"
+    delegate_to: "{{ groups['satellite6']|first }}"
+    run_once: true
+    with_items: "{{ groups['capsules'] }}"
+    when: "sat_version == '6.3'"
     # Output of this command looks like this:
     # # capsule-certs-generate --capsule-fqdn capsule.example.com --certs-tar aaa.tar
     # Installing             Done                                               [100%] [..........]
@@ -122,6 +133,12 @@
   - name: "Fix certificate tarball path"
     shell:
       sed -i 's|/var/www/html/pub/{{ inventory_hostname }}-certs.tar|/root/{{ inventory_hostname }}-certs.tar|' "/root/{{ inventory_hostname }}-script.sh"
+
+  # Fix for BZ 1458749
+  - name: "Fix the capsule scenario"
+    shell:
+      sed -i 's|--scenario foreman-proxy-content|--scenario capsule|' "/root/{{ inventory_hostname }}-script.sh"
+    when: "sat_version == '6.3'"
 
   # Make sure remote execution plugin is enabled
   # https://bugzilla.redhat.com/show_bug.cgi?id=1402240

--- a/playbooks/satellite/roles/rhsm-satellite/tasks/main.yaml
+++ b/playbooks/satellite/roles/rhsm-satellite/tasks/main.yaml
@@ -40,7 +40,7 @@
     delay: 10
   - name: "Determine pool we are going to attach to"
     command:
-      subscription-manager list --available --all --matches "{{ rhsm_pool }}" --pool-only
+      subscription-manager list --available --all --matches "{{ base_capsule_pool }}" --pool-only
     register: querying
     until: "{{ querying.rc }} == 0"
     retries: 5


### PR DESCRIPTION
1) Added new variables base_capsule_pool, sat_version and
   extend_root_partition to satperf.yaml file.
2) All the new variables default values  are set/configured for sat6.2
   and satperf setups.
3) Make extend root partition optional
4) Added a fix for the BZ 1458749
5) Introduced base_capsule_pool as every manifest may not have,
   'Employee SKU' and via rhsm-satellite task we are enabling,
   the pool rhsm_pool, which is "Employee SKU".