### PR TITLE
Automate the downloading of the grafana graphs after our experiment runs

### DIFF
--- a/conf/satperf.yaml
+++ b/conf/satperf.yaml
@@ -155,6 +155,35 @@ grafana_port: 3000
 grafana_username: admin
 grafana_password: admin
 
+#Grafana Panel Mappings
+grafana_panel_mapping:
+  cpu: 1
+  memory: 5
+  http_cpu: 43
+  dynflow_cpu: 44
+  smartproxy_cpu: 45
+  mongodb_cpu: 46
+  passenger_cpu: 47
+  postgres_cpu: 48
+  pulp_cpu: 49
+  puppet_agent_cpu: 50
+  qpidd_cpu: 51
+  tomcat_cpu: 52
+  http_mem: 56
+  dynflow_mem: 57
+  smartproxy_mem: 58
+  mongodb_mem: 59
+  passenger_mem: 60
+  postgres_mem: 61
+  pulp_mem: 62
+  puppet_agent_mem: 63
+  qpidd_mem: 64
+  tomcat_mem: 65
+  postgres_db_size: 108
+  postgres_connected_clients: 109
+  postgres_foreman_op: 113
+  postgres_candlepin_op: 114
+
 # If you have some service where you can add results of experiments, set its hostname
 recorder_server: ''
 

--- a/playbooks/satellite/roles/grafana-graph-download/tasks/main.yaml
+++ b/playbooks/satellite/roles/grafana-graph-download/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+  - name: Ensure that start and end timestamps are present
+    assert:
+      that:
+        - "start_time is defined"
+        - "end_time is defined"
+  - name: Verify if the username and password pairs are present for grafana
+    assert:
+      that:
+        - "grafana_username is defined"
+        - "grafana_password is defined"
+  - name: Generate a prefix for output file name
+    set_fact:
+      output_filename_prefix: "{{ start_time }}_{{ end_time }}" 
+  - name: Download the graphs
+    get_url:
+      url: "http://{{ grafana_username }}:{{ grafana_password }}@grafana.perf.lab.eng.bos.redhat.com/render/dashboard-solo/db/satellite6-general-system-performance?from={{ start_time }}&to={{ end_time }}&var-Cloud=satellite62&var-Node={{ satellite_hostname }}&var-Interface=interface-em2&var-Disk=disk-sda&var-cpus0=All&var-cpus00=All&panelId={{ item.value }}&width=1000&height=500"
+      dest: "{{ output_filename_prefix }}_{{ item.key }}"
+    with_dict: "{{ grafana_panels }}"
+...

--- a/playbooks/tests/registrations.yaml
+++ b/playbooks/tests/registrations.yaml
@@ -127,4 +127,6 @@
         - name: sat6_proc_cpu_sum
           panelId: 43
       when: "save_graphs == 'true'"
+  roles:
+      - grafana-graph-download
 ...

--- a/playbooks/tests/roles/grafana-graph-download/tasks/main.yaml
+++ b/playbooks/tests/roles/grafana-graph-download/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+  - name: Ensure that start and end timestamps are present
+    assert:
+      that:
+        - "start_time is defined"
+        - "end_time is defined"
+  - name: Verify if the username and password pairs are present for grafana
+    assert:
+      that:
+        - "grafana_username is defined"
+        - "grafana_password is defined"
+  - name: Generate a prefix for output file name
+    set_fact:
+      output_filename_prefix: "{{ start_time }}_{{ end_time }}" 
+  - name: Download the graphs
+    get_url:
+      url: "http://{{ grafana_username }}:{{ grafana_password }}@grafana.perf.lab.eng.bos.redhat.com/render/dashboard-solo/db/satellite6-general-system-performance?from={{ start_time }}&to={{ end_time }}&var-Cloud=satellite62&var-Node={{ satellite_hostname }}&var-Interface=interface-em2&var-Disk=disk-sda&var-cpus0=All&var-cpus00=All&panelId={{ item.value }}&width=1000&height=500"
+      dest: "{{ output_filename_prefix }}_{{ item.key }}"
+    with_dict: "{{ grafana_panels }}"
+...


### PR DESCRIPTION
We need to understand a number of metrics after our experiment finishes the run
These changes allow us to automate the downloading of the different graphs from grafana and save them

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>